### PR TITLE
engine.deck.Deck.__len__() and refactor

### DIFF
--- a/engine/deck.py
+++ b/engine/deck.py
@@ -3,23 +3,14 @@ from random import shuffle, Random
 
 class Deck(object):
 
-    def __init__(self, colors, seed=False):
+    def __init__(self, colors, values=(1, 1, 1, 2, 2, 3, 3, 4, 4, 5), seed=False):
         self.colors = colors
 
         deck = []
 
-        # Not sure if this would look prettier rolled into more loops
         for color in self.colors:
-            deck.append(Card(1, color))
-            deck.append(Card(1, color))
-            deck.append(Card(1, color))
-            deck.append(Card(2, color))
-            deck.append(Card(2, color))
-            deck.append(Card(3, color))
-            deck.append(Card(3, color))
-            deck.append(Card(4, color))
-            deck.append(Card(4, color))
-            deck.append(Card(5, color))
+            for value in values:
+                deck.append(Card(value, color))
 
         self.deck = deck
 
@@ -28,6 +19,8 @@ class Deck(object):
         else:
             shuffle(self.deck)
 
+    def __len__(self):
+        return len(self.deck)
 
     def __repr__(self):
         return "Deck: {cardlist}".format(cardlist=[c for c in self.deck])

--- a/engine/game.py
+++ b/engine/game.py
@@ -20,10 +20,9 @@ class Game(object):
         self.deck = Deck(self.colors, seed=deck_seed)
         self.player_hands = [[] for _ in range(len(self.players))]
         self.master_game_state = GameState(Board(self.colors,
-                                                 self.deck.get_deck_size(),
+                                                 len(self.deck),
                                                  range(len(self.players))),
-                                                 self.player_hands
-                                           )
+                                                 self.player_hands)
         self.game_almost_over = None
 
     def deal_initial_hand(self):
@@ -59,7 +58,7 @@ class Game(object):
     # Turn order: move, check end, draw card, initiate final round, next player
     def play_game(self):
         self.deal_initial_hand()
-        self.master_game_state.board.update_deck_size(self.deck.get_deck_size())
+        self.master_game_state.board.update_deck_size(len(self.deck))
         for player_id in cycle(range(len(self.players))):
             player_game_state = PlayerGameState(self.master_game_state, player_id)
             new_move = self.players[player_id].make_move(player_game_state)
@@ -72,12 +71,12 @@ class Game(object):
                 game_score = self.master_game_state.board.compute_score()
                 print("Game over: Score {score}".format(score=game_score))
                 return game_score
-            if self.deck.get_deck_size() > 0:
+            if len(self.deck) > 0:
                 self.player_hands[player_id].append(self.deck.draw_card())
                 self.master_game_state.player_hands = self.player_hands
-                self.master_game_state.board.update_deck_size(self.deck.get_deck_size())
+                self.master_game_state.board.update_deck_size(len(self.deck))
             # This triggers when the last card is drawn, every player including this one takes one more turn.
-            if self.deck.get_deck_size() == 0 and self.game_almost_over == None:
+            if len(self.deck) == 0 and self.game_almost_over == None:
                 self.game_almost_over = player_id
 
 


### PR DESCRIPTION
Created `engine.deck.Deck.__len__()` so that `len(aDeck)` returns the number of remaining cards in the deck.

Refactored `engine.game` to use `len(aDeck)` instead of `aDeck.get_deck_size()`.

Also, added `values` parameter to `engine.deck.Deck.__init__()`. When a `Deck` is created it adds one card for each element of `values` for each element of `self.color`.